### PR TITLE
更新requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ requests~=2.22.0
 requests-html~=0.10.0
 
 # repeater
-pydantic~=1.9.0
+pydantic~=1.10.0
 pymongo~=3.12.1
 jieba-fast~=0.53
 pypinyin~=0.41.0


### PR DESCRIPTION
原有的`pydantic~=1.9.0`会导致nonebot报错(~~牛牛过时了~~)，
nonebot要求`pydantic[dotenv]<2.0.0,>=1.10.0`
换成1.10.0版本就好了