### PR TITLE
更新依赖与搭建教程

### DIFF
--- a/DeploymentTutorial.md
+++ b/DeploymentTutorial.md
@@ -6,6 +6,8 @@
 
 - 你需要一个额外的 QQ 小号，一台自己的 `电脑` 或 `服务器`，请不要用大号进行部署
 - 你自己部署的牛牛与其他牛牛数据并不互通，是一张白纸，需要从头调教
+- Pallas-Bot 需要 python 环境为 python3.8 | python3.9 | python3.10
+- 提供 `requirements.txt` 文件，可以自行安装依赖，但是推荐使用 poetry 进行依赖管理
 
 ## Windows系统
 
@@ -28,62 +30,47 @@
 1. 解压下载好的 Pallas-Bot 源码并进入根目录；请**务必**进入文件夹后再进行后面的操作
 
 2. 在 Pallas-Bot 的目录打开 `命令行窗口`（俗称 cmd ）
-3. 更换 pip 源为阿里云*（更换为国内源会比默认的国外源快很多）
+
+3. 安装 poetry 管理 python 环境
 
     ```cmd
-    python3 -m pip config set global.index-url http://mirrors.aliyun.com/pypi/simple/
-    ```
+   python3 -m pip install poetry    
+   ```
+   如果系统无法识别 `python3` 指令。则需要将 `python3` 添加到环境变量中，具体请自行搜索解决方法。
 
-    或者你也可以搜索如何更换为其他的国内源；如果系统无法识别 `python3` 指令。则需要将 `python3` 添加到环境变量中，具体请自行搜索解决方法。
+4. 安装依赖
 
-4. 通过手脚架安装nonebot
+   ```cmd
+   poetry install
+   ```
 
-    ```cmd
-    python3 -m pip install nb-cli
-    ```
-
-    详情参见 [安装 NoneBot2](https://v2.nonebot.dev/docs/start/installation)
-
-5. 安装依赖
-
-    ```cmd
-    python3 -m pip install -r requirements.txt
-    ```
-
-    （如果这些依赖与其他 Python 程序产生了冲突，请自行搜索如何构建python虚拟环境）
-
-6. 安装 nonebot 的 apscheduler 插件和 websockets 驱动器
-
-    ```cmd
-    nb plugin install nonebot_plugin_apscheduler
-    nb plugin install nonebot_plugin_gocqhttp
-    nb driver install websockets
-    ```
-
-    （如果你的系统提示找不到 `nb`，请自行尝试添加相关环境变量~）
-
-7. 安装并启动 Mongodb （这是启动核心功能所必须的）
+5. 安装并启动 Mongodb （这是启动核心功能所必须的）
 
     👉 [Windows 平台安装 MongoDB](https://www.runoob.com/mongodb/mongodb-window-install.html)
 
     只需要确认 Mongodb 启动即可，后面的部分会由 Pallas-Bot 自动完成
 
-8. 配置 ffmpeg （如果不希望牛牛发送语音，可以跳过这一步）
+6. 配置 ffmpeg （如果不希望牛牛发送语音，可以跳过这一步）
 
     👉 [安装 ffmpeg](https://docs.go-cqhttp.org/guide/quick_start.html#%E5%AE%89%E8%A3%85-ffmpeg)
 
-9. 配置文心文生图 key （如果不需要 `牛牛做梦` 功能，可以跳过这一步）
+7. 配置文心文生图 key （如果不需要 `牛牛做梦` 功能，可以跳过这一步）
 
     1. 前往 [文心大模型](https://wenxin.baidu.com/moduleApi/ernieVilg) 申请你的 key
     2. 修改牛牛代码 `src/plugins/dream/__init__.py`，将 `wenxin_ak` 和 `wenxin_sk` 改成你申请到的两个字符串
 
 ### 启动 Pallas-Bot
-
 在项目目录处打开 cmd（命令行）窗口输入以下指令
 
-```cmd
-nb run
-```
+   ```cmd
+   poetry shell
+   ```
+
+进入虚拟环境后输入以下指令启动 Pallas-Bot
+
+   ```cmd
+   nb run
+   ```
 
 **注意！请不要关闭这个命令行窗口！这会导致 Pallas-Bot 停止运行！**
 
@@ -103,45 +90,30 @@ sudo apt install -y git python3 # 安装 git, python3
 sudo ldconfig                   # 更新系统路径
 python3 -m pip config set global.index-url http://mirrors.aliyun.com/pypi/simple/ # 更换 pip 源为国内源
 python3 -m pip install --upgrade pip # 更新 pip
+python3 -m pip install poetry   # 安装 poetry
 ```
 
 ### 配置 Linux 运行环境
 
-1. 安装 nonebot
-
-    ```bash
-    python3 -m pip install nb-cli
-    ```
-
-    详情参见 [安装 NoneBot2](https://v2.nonebot.dev/docs/start/installation)
-
-2. clone 本仓库并安装项目依赖
+1. clone 本仓库并安装项目依赖
 
     ```bash  
     git clone https://github.com/InvoluteHell/Pallas-Bot.git
     cd Pallas-Bot
-    python3 -m pip install -r requirements.txt
+    poetry install
     ```
 
-3. 安装 nonebot 的 apscheduler 插件和 websockets 驱动器
-
-    ```bash
-    nb plugin install nonebot_plugin_apscheduler
-    nb plugin install nonebot_plugin_gocqhttp
-    nb driver install websockets
-    ```
-
-4. 安装并启动 Mongodb （这是启动核心功能所必须的）
+2. 安装并启动 Mongodb （这是启动核心功能所必须的）
 
     👉 [Linux 平台安装 MongoDB](https://www.runoob.com/mongodb/mongodb-linux-install.html)
 
-5. 安装 ffmpeg （如果不希望牛牛发送语音，可以跳过这一步）
+3. 安装 ffmpeg （如果不希望牛牛发送语音，可以跳过这一步）
 
     ```bash
     sudo apt install -y ffmpeg
     ```
 
-6. 配置文心文生图 key （如果不需要 `牛牛做梦` 功能，可以跳过这一步）
+4. 配置文心文生图 key （如果不需要 `牛牛做梦` 功能，可以跳过这一步）
 
     1. 前往 [文心大模型](https://wenxin.baidu.com/moduleApi/ernieVilg) 申请你的 key
     2. 修改牛牛代码 `src/plugins/dream/__init__.py`，将 `wenxin_ak` 和 `wenxin_sk` 改成你申请到的两个字符串

--- a/DeploymentTutorial.md
+++ b/DeploymentTutorial.md
@@ -134,6 +134,27 @@ python3 -m pip install poetry   # 安装 poetry
 
 当然要是有大佬帮忙给插件写个备份机制就更好啦 ✿✿ヽ(°▽°)ノ✿
 
+### 使用的是国外的机子怎么办
+
+因为项目默认使用的是国内的 pip 源，所以如果你的机子在国外，那么在安装依赖的时候可能会出现下载失败的情况。
+
+解决方法是在 `pyproject.toml` 中删除以下内容：
+
+```toml
+[[tool.poetry.source]]
+name = "aliyun"
+url = "https://mirrors.aliyun.com/pypi/simple"
+default = true
+```
+
+然后重新安装依赖即可。
+
+也可以使用如下命令重新导出一份`requirements.txt`文件，然后使用国外的源安装依赖：
+
+```bash
+poetry export --without-hashes -f requirements.txt --output requirements.txt
+```
+
 ## 开发者群
 
 QQ 群: [牛牛听话！](https://jq.qq.com/?_wv=1027&k=tlLDuWzc)  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,27 @@ authors = []
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.7.3"
-nonebot2 = "^2.0.0-beta.1"
+python = "^3.8"
+nonebot2 = {extras = ["fastapi"], version = "^2.0.0rc3"}
+nonebot-adapter-onebot = "^2.2.1"
+requests = "^2.28.2"
+requests-html = "^0.10.0"
+pydantic = "^1.10.4"
+pymongo = "^4.3.3"
+jieba-fast = "^0.53"
+pypinyin = "^0.48.0"
+wenxin-api = "^0.2.1"
+asyncer = "^0.0.2"
+nonebot-plugin-apscheduler = "^0.2.0"
+nonebot-plugin-gocqhttp = "^0.6.4"
 
 [tool.poetry.dev-dependencies]
 nb-cli = "^0.6.0"
+
+[[tool.poetry.source]]
+name = "aliyun"
+url = "https://mirrors.aliyun.com/pypi/simple"
+default = true
 
 [tool.nonebot]
 plugins = ["nonebot_plugin_apscheduler", "nonebot_plugin_gocqhttp"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,73 @@
-# main
-nonebot2~=2.0.0b2
-nonebot-adapter-onebot~=2.0.0b1
+--index-url https://mirrors.aliyun.com/pypi/simple
 
-# # tests
-# pytest~=7.1.2
-
-# greeting
-requests~=2.22.0
-requests-html~=0.10.0
-
-# repeater
-pydantic~=1.10.0
-pymongo~=3.12.1
-jieba-fast~=0.53
-pypinyin~=0.41.0
-
-# dream
-wenxin-api~=0.0.5.1
-asyncer~=0.0.1
+anyio==3.6.2 ; python_version >= "3.8" and python_version < "4.0"
+appdirs==1.4.4 ; python_version >= "3.8" and python_version < "4.0"
+apscheduler==3.10.0 ; python_version >= "3.8" and python_version < "4.0"
+asyncer==0.0.2 ; python_version >= "3.8" and python_version < "4.0"
+backports-zoneinfo==0.2.1 ; python_version >= "3.8" and python_version < "3.9"
+beautifulsoup4==4.11.2 ; python_version >= "3.8" and python_version < "4.0"
+bs4==0.0.1 ; python_version >= "3.8" and python_version < "4.0"
+certifi==2022.12.7 ; python_version >= "3.8" and python_version < "4"
+charset-normalizer==3.0.1 ; python_version >= "3.8" and python_version < "4"
+chevron==0.14.0 ; python_version >= "3.8" and python_version < "4.0"
+click==8.1.3 ; python_version >= "3.8" and python_version < "4.0"
+colorama==0.4.6 ; python_version >= "3.8" and python_version < "4.0" and sys_platform == "win32" or python_version >= "3.8" and python_version < "4.0" and platform_system == "Windows"
+cssselect==1.2.0 ; python_version >= "3.8" and python_version < "4.0"
+dnspython==2.3.0 ; python_version >= "3.8" and python_version < "4.0"
+fake-useragent==1.1.1 ; python_version >= "3.8" and python_version < "4.0"
+fastapi==0.89.1 ; python_version >= "3.8" and python_version < "4.0"
+h11==0.14.0 ; python_version >= "3.8" and python_version < "4.0"
+httpcore==0.16.3 ; python_version >= "3.8" and python_version < "4.0"
+httptools==0.5.0 ; python_version >= "3.8" and python_version < "4.0"
+httpx==0.23.3 ; python_version >= "3.8" and python_version < "4.0"
+idna==3.4 ; python_version >= "3.8" and python_version < "4"
+importlib-metadata==6.0.0 ; python_version >= "3.8" and python_version < "4.0"
+importlib-resources==5.10.2 ; python_version >= "3.8" and python_version < "3.10"
+jieba-fast==0.53 ; python_version >= "3.8" and python_version < "4.0"
+loguru==0.6.0 ; python_version >= "3.8" and python_version < "4.0"
+lxml==4.9.2 ; python_version >= "3.8" and python_version < "4.0"
+msgpack==1.0.4 ; python_version >= "3.8" and python_version < "4.0"
+multidict==6.0.4 ; python_version >= "3.8" and python_version < "4.0"
+nonebot-adapter-onebot==2.2.1 ; python_version >= "3.8" and python_version < "4.0"
+nonebot-plugin-apscheduler==0.2.0 ; python_version >= "3.8" and python_version < "4.0"
+nonebot-plugin-gocqhttp==0.6.4 ; python_version >= "3.8" and python_version < "4.0"
+nonebot2==2.0.0rc3 ; python_version >= "3.8" and python_version < "4.0"
+nonebot2[fastapi]==2.0.0rc3 ; python_version >= "3.8" and python_version < "4.0"
+parse==1.19.0 ; python_version >= "3.8" and python_version < "4.0"
+psutil==5.9.4 ; python_version >= "3.8" and python_version < "4.0"
+py-cpuinfo==9.0.0 ; python_version >= "3.8" and python_version < "4.0"
+pydantic==1.10.4 ; python_version >= "3.8" and python_version < "4.0"
+pydantic[dotenv]==1.10.4 ; python_version >= "3.8" and python_version < "4.0"
+pyee==8.2.2 ; python_version >= "3.8" and python_version < "4.0"
+pygtrie==2.5.0 ; python_version >= "3.8" and python_version < "4.0"
+pymongo==4.3.3 ; python_version >= "3.8" and python_version < "4.0"
+pypinyin==0.48.0 ; python_version >= "3.8" and python_version < "4"
+pyppeteer==1.0.2 ; python_version >= "3.8" and python_version < "4.0"
+pyquery==2.0.0 ; python_version >= "3.8" and python_version < "4.0"
+python-dotenv==0.21.1 ; python_version >= "3.8" and python_version < "4.0"
+pytz-deprecation-shim==0.1.0.post0 ; python_version >= "3.8" and python_version < "4.0"
+pytz==2022.7.1 ; python_version >= "3.8" and python_version < "4.0"
+pyyaml==6.0 ; python_version >= "3.8" and python_version < "4.0"
+requests-html==0.10.0 ; python_version >= "3.8" and python_version < "4.0"
+requests==2.28.2 ; python_version >= "3.8" and python_version < "4"
+rfc3986[idna2008]==1.5.0 ; python_version >= "3.8" and python_version < "4.0"
+setuptools==67.1.0 ; python_version >= "3.8" and python_version < "4.0"
+six==1.16.0 ; python_version >= "3.8" and python_version < "4.0"
+sniffio==1.3.0 ; python_version >= "3.8" and python_version < "4.0"
+soupsieve==2.3.2.post1 ; python_version >= "3.8" and python_version < "4.0"
+starlette==0.22.0 ; python_version >= "3.8" and python_version < "4.0"
+tomlkit==0.11.6 ; python_version >= "3.8" and python_version < "4.0"
+tqdm==4.64.1 ; python_version >= "3.8" and python_version < "4.0"
+typing-extensions==4.4.0 ; python_version >= "3.8" and python_version < "4.0"
+tzdata==2022.7 ; python_version >= "3.8" and python_version < "4.0"
+tzlocal==4.2 ; python_version >= "3.8" and python_version < "4.0"
+urllib3==1.26.14 ; python_version >= "3.8" and python_version < "4"
+uvicorn[standard]==0.20.0 ; python_version >= "3.8" and python_version < "4.0"
+uvloop==0.17.0 ; sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy" and python_version >= "3.8" and python_version < "4.0"
+w3lib==2.1.1 ; python_version >= "3.8" and python_version < "4.0"
+watchfiles==0.18.1 ; python_version >= "3.8" and python_version < "4.0"
+websockets==10.4 ; python_version >= "3.8" and python_version < "4.0"
+wenxin-api==0.2.1 ; python_version >= "3.8" and python_version < "4.0"
+win32-setctime==1.1.0 ; python_version >= "3.8" and python_version < "4.0" and sys_platform == "win32"
+yarl==1.8.2 ; python_version >= "3.8" and python_version < "4.0"
+zipp==3.12.0 ; python_version >= "3.8" and python_version < "4.0"


### PR DESCRIPTION
更新了依赖，适配了 nonebot2 最近的更新要求
更新部署文档，使用 poetry 管理依赖（逃

现在项目内的 pip 源默认为 aliyun 的了，不需要另外设置
如果部署在海外服务器，需要更改一下 pyproject.toml
```
[[tool.poetry.source]]
name = "aliyun"
url = "https://mirrors.aliyun.com/pypi/simple"
default = true
```
将这段删去