### PR TITLE
更新部署文档中pip源地址为https协议

### DIFF
--- a/DeploymentTutorial.md
+++ b/DeploymentTutorial.md
@@ -88,7 +88,7 @@
 sudo apt update
 sudo apt install -y git python3 # 安装 git, python3
 sudo ldconfig                   # 更新系统路径
-python3 -m pip config set global.index-url http://mirrors.aliyun.com/pypi/simple/ # 更换 pip 源为国内源
+python3 -m pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/ # 更换 pip 源为国内源
 python3 -m pip install --upgrade pip # 更新 pip
 python3 -m pip install poetry   # 安装 poetry
 ```


### PR DESCRIPTION
协议为http时会导致pip更新失败，导致后续依赖无法安装，已经修正为https协议