### PR TITLE
修复在Windows下牛牛唱歌无法指定GPU的问题

### DIFF
--- a/src/plugins/sing/separater.py
+++ b/src/plugins/sing/separater.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from threading import Lock
 from pathlib import Path
 
@@ -22,7 +23,10 @@ def separate(song_path: Path, output_dir: Path, locker: Lock = Lock()):
         # 这个库没提供 APIs，暂时简单粗暴用命令行了
         cmd = ''
         if cuda_devices:
-            cmd = f'CUDA_VISIBLE_DEVICES={cuda_devices} '
+            if platform.system() == 'Windows':
+                cmd = f'set CUDA_VISIBLE_DEVICES={cuda_devices} && '
+            else:
+                cmd = f'CUDA_VISIBLE_DEVICES={cuda_devices} '
         cmd += f'python -m demucs --two-stems=vocals --mp3 --mp3-bitrate 128 -n {MODEL} {str(song_path)} -o {output_dir}'
         with locker:
             print(cmd)

--- a/src/plugins/sing/svc_inference.py
+++ b/src/plugins/sing/svc_inference.py
@@ -66,7 +66,10 @@ def inference(song_path: Path, output_dir: Path, key: int = 0, speaker: str = "p
 
         cmd = ''
         if cuda_devices:
-            cmd = f'CUDA_VISIBLE_DEVICES={cuda_devices} '
+            if platform.system() == 'Windows':
+                cmd = f'set CUDA_VISIBLE_DEVICES={cuda_devices} && '
+            else:
+                cmd = f'CUDA_VISIBLE_DEVICES={cuda_devices} '
         cmd += f'python {SVC_MAIN} -m {model} -c {config} -hb {SVC_HUBERT.absolute()} \
             -f {song_path.absolute()} -t {key} -s {speaker} -sd {SVC_SLICE_DB} -sf {SVC_FORCE_SLICE}\
             -o {output_dir.absolute()} -wf {SVC_OUPUT_FORMAT}'


### PR DESCRIPTION
直接设置 `os.environ['CUDA_VISIBLE_DEVICES']` 虽然有用但貌似会影响全局的GPU编号顺序，卡多的话多换几次全乱套了，试了试还是用 `set CUDA_VISIBLE_DEVICES=XXX` 比较好