### PR TITLE
fix(sec): upgrade gradio to 3.34.0

### DIFF
--- a/src/plugins/sing/requirements.txt
+++ b/src/plugins/sing/requirements.txt
@@ -6,7 +6,7 @@ asyncer
 ### so-vits-svc ###
 Flask>=2.1.2
 Flask_Cors>=3.0.10
-gradio>=3.4.1
+gradio>=3.34.0
 numpy>=1.19.2
 playsound>=1.3.0
 PyAudio>=0.2.12


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in gradio 3.4.1
- [CVE-2023-25823](https://www.oscs1024.com/hd/CVE-2023-25823)


### What did I do？
Upgrade gradio from 3.4.1 to 3.34.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS