### PR TITLE
build & docs: docker部署支持使用CPU推理的AI功能；更新文档

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,29 @@ jobs:
           tags: |
             type=raw,value=latest
 
-      - name: Build and Publish
+      - name: Build and Publish Base
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: Dockerfile
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+      
+      - name: Generate AI Tags
+        uses: docker/metadata-action@v4
+        id: aimetadata
+        with:
+          images: |
+            misteo/pallas-bot
+          tags: |
+            type=raw,value=latest-ai
+
+      - name: Build and Publish AI
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: AI.Dockerfile
+          push: true
+          tags: ${{ steps.aimetadata.outputs.tags }}
+          labels: ${{ steps.aimetadata.outputs.labels }}

--- a/AI.Dockerfile
+++ b/AI.Dockerfile
@@ -33,3 +33,21 @@ RUN pip install --no-cache-dir --upgrade -r requirements.txt
 RUN rm requirements.txt
 
 COPY ./ /app/
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y portaudio19-dev python3-all-dev
+
+RUN git submodule update --init --recursive
+
+RUN pip install --no-cache-dir --upgrade -r src/plugins/sing/requirements.txt
+
+RUN pip install --no-cache-dir torch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0
+
+RUN pip install tokenizers rwkv
+
+RUN pip install --no-cache-dir paddlepaddle==2.4.2 paddlespeech==1.3.0
+
+RUN pip install --no-cache-dir numpy==1.23.5 typeguard==2.13.3
+
+COPY ./ /app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     volumes:
       - /opt/dockerstore/pallas-bot/resource/:/app/resource
       - /opt/dockerstore/pallas-bot/accounts/:/app/accounts
+      - /opt/dockerstore/pallas-bot/.env.prod:/app/.env.prod
     depends_on:
       - mongodb
 
@@ -37,6 +38,15 @@ services:
     volumes:
       - /opt/dockerstore/mongo/data:/data/db
       - /opt/dockerstore/mongo/logs:/var/log/mongodb
+
+  qsign:
+    container_name: qsign
+    image: xzhouqd/qsign:8.9.63
+    environment:
+      - PORT=8080
+      - COUNT=3
+      - ANDROID_ID=114514
+    restart: always
 
 networks:
   pallasbot:

--- a/docs/AIDeployment.md
+++ b/docs/AIDeployment.md
@@ -20,7 +20,7 @@ AI 功能均对设备硬件要求较高，且配置操作更加复杂一些。�
 
 2. 更新 git 子模块
 
-    ```
+    ```bash
     git submodule update --init --recursive
     ```
 
@@ -37,7 +37,7 @@ AI 功能均对设备硬件要求较高，且配置操作更加复杂一些。�
 
     - GPU  
 
-        需要 5G 或更高**显存**，否则跑不起来，P106-100 (差不多 GTX1060 的性能）合成 60 秒音频大概需要 30 秒
+        需要 5G 或更高**显存**，否则跑不起来，P106-100 （差不多 GTX1060 的性能）合成 60 秒音频大概需要 30 秒
 
         ```bash
         python -m pip install -r src/plugins/sing/requirements.txt
@@ -59,14 +59,15 @@ AI 功能均对设备硬件要求较高，且配置操作更加复杂一些。�
     ```
 
     - GPU
-    
+
     ```bash
     python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cu117
     python -m pip install tokenizers rwkv
     ```
 
-4. `src/plugins/chat/prompt.py` 里的起手咒语 `INIT_PROMPT` 有兴趣可以试着改改
-5. `src/plugins/chat/model.py` 里的 `STRATEGY` 可以按上游仓库的 [说明](https://github.com/BlinkDL/ChatRWKV/tree/main#%E4%B8%AD%E6%96%87%E6%A8%A1%E5%9E%8B) 改改，能省点显存啥的
+3. `src/plugins/chat/prompt.py` 里的起手咒语 `INIT_PROMPT` 有兴趣可以试着改改
+
+4. `src/plugins/chat/model.py` 里的 `STRATEGY` 可以按上游仓库的 [说明](https://github.com/BlinkDL/ChatRWKV/tree/main#%E4%B8%AD%E6%96%87%E6%A8%A1%E5%9E%8B) 改改，能省点显存啥的
 
 ## 酒后语音说话（TTS）
 
@@ -75,11 +76,12 @@ AI 功能均对设备硬件要求较高，且配置操作更加复杂一些。�
 1. 下载 [模型资源](https://huggingface.co/MistEO/Pallas-Bot/tree/main/paddlespeech/tts) common.zip 和 pallas_cn.zip。解压放入 `resource/tts/models` 文件夹中
     - 具体路径结构请参考 [path_structure.txt](../resource/tts/models/path_structure.txt)
     - `vocoder` 下有两个声码器，`pwgan_aishell3` 快，`wavernn_csmsc` 慢很多效果好一点，可以自行选择
+
 2. 安装依赖
 
     - CPU 版本（合成耗时 20s 左右）
 
-        ```
+        ```bash
         python3 -m pip install paddlepaddle-gpu==2.4.2.post117 paddlespeech==1.3.0 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
         ```
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -6,7 +6,7 @@
 
 - 你需要一个额外的 QQ 小号，一台自己的 `电脑` 或 `服务器`，不推荐用大号进行部署
 - 你自己部署的牛牛与其他牛牛数据并不互通，是一张白纸，需要从头调教
-- 牛牛的基础功能（不包含 AI 功能）支持使用 Docker Compose 一键部署，可以参考 [Docker 部署](#docker-部署)
+- 牛牛的基础功能和使用 CPU 推理的 AI 功能支持使用 Docker Compose 一键部署，可以参考 [Docker 部署](DockerDeployment.md)。GPU 版本正在开发测试中。
 
 ## 基本环境配置
 
@@ -105,56 +105,6 @@ nb run        # 运行
 ```bash
 git pull origin master --autostash
 ```
-
-## Docker 部署
-
-如果你不想自己配置环境，且只想使用牛牛的基础功能，可以使用 Docker Compose 一键部署已构建好的镜像：
-
-1. 安装 Docker 与 Docker Compose
-
-    - [Windows Docker Desktop 安装](https://docs.docker.com/desktop/install/windows-install/) ，推荐使用基于 [WSL 2](https://learn.microsoft.com/zh-cn/windows/wsl/install) 的 Docker CE
-    - [Linux Docker 安装](https://docs.docker.com/engine/install/ubuntu/)，推荐使用 `curl -sSL https://get.daocloud.io/docker | sh` 命令一键安装
-    - 安装 [Docker Compose 插件](https://docs.docker.com/compose/install/linux/)，如果你之前已经安装过 Docker，推荐 [单独安装 Docker Compose](https://docs.docker.com/compose/install/other/)。Windows 用户可以直接在 Docker Desktop 中启用 Docker Compose（Settings -> General -> Use Docker Compose V2）。
-
-    不要忘了[配置镜像加速](https://www.runoob.com/docker/docker-mirror-acceleration.html)
-
-2. 复制一份 [docker-compose.yml](../docker-compose.yml) 文件到本地单独的目录并按需修改 `volumes` 的路径
-
-    ```yml
-    ...
-    volumes:
-    # 根据需求修改冒号左边路径
-    # Windows用户请修改左边为 D:\Pallas-Bot 这样的路径
-        - /opt/dockerstore/pallas-bot/resource/:/app/resource
-        - /opt/dockerstore/pallas-bot/accounts/:/app/accounts
-    ...
-    volumes:
-    # 同上
-      - /opt/dockerstore/mongo/data:/data/db
-      - /opt/dockerstore/mongo/logs:/var/log/mongodb
-    ...
-    ```
-
-3. 在 docker-compose.yml 所在目录下创建 [.env.prod](../.env.prod) 文件
-
-4. 启动牛牛并在后台运行
-    插件形式安装的 Docker Compose 请使用 `docker compose` 代替 `docker-compose`
-
-    ```bash
-    # Windows 管理员/Linux root 用户在 docker-compose.yml 所在目录下执行
-    docker-compose up -d
-    ```
-
-    可以通过 `docker-compose logs -f` 查看实时日志，启动完成后就可以[访问后台并登陆账号](#访问后台并登陆账号)了。日志中报错未成功加载 `chat` 和 `sing` 插件是正常的，因为目前的镜像未安装相关依赖。
-
-5. 后续更新
-
-    ```bash
-    # Windows 管理员/Linux root 用户在 docker-compose.yml 所在目录下执行
-    docker-compose down     # 停止容器
-    docker-compose pull     # 拉取最新镜像
-    docker-compose up -d    # 重新启动容器
-    ```
 
 ## AI 功能
 

--- a/docs/DockerDeployment.md
+++ b/docs/DockerDeployment.md
@@ -1,0 +1,109 @@
+# Docker 部署
+
+如果你不想自己配置环境，可以使用 Docker Compose 一键部署已构建好的镜像。镜像中集成了包括  `python`、`ffmpeg` 甚至 `qsign` 等在内的所有环境并经过充分测试，你只需要安装 Docker 和 Docker Compose 即可。目前有基础功能镜像和支持 CPU 版本的所有 AI 功能的镜像，GPU 版本的 AI 功能镜像正在测试中。
+
+## 准备工作
+
+### 安装 Docker 与 Docker Compose
+
+- [Windows Docker Desktop 安装](https://docs.docker.com/desktop/install/windows-install/) ，推荐使用基于 [WSL 2](https://learn.microsoft.com/zh-cn/windows/wsl/install) 的 Docker CE
+
+- [Linux Docker 安装](https://docs.docker.com/engine/install/ubuntu/)，推荐使用 `curl -sSL https://get.daocloud.io/docker | sh` 命令一键安装
+
+- 安装 [Docker Compose 插件](https://docs.docker.com/compose/install/linux/)，如果你之前已经安装过 Docker，推荐 [单独安装 Docker Compose](https://docs.docker.com/compose/install/other/)。Windows 用户可以直接在 Docker Desktop 中启用 Docker Compose（Settings -> General -> Use Docker Compose V2）。
+
+不要忘了[配置镜像加速](https://www.runoob.com/docker/docker-mirror-acceleration.html)
+
+### 配置 docker-compose.yml
+
+1. 复制一份 [docker-compose.yml](../docker-compose.yml) 文件到本地单独的目录并按需修改 `volumes` 的路径：
+
+    ```yml
+    ...
+    volumes:
+    # 根据需求修改冒号左边路径
+    # Windows用户请修改左边为 D:\Pallas-Bot 这样的路径
+        - /opt/dockerstore/pallas-bot/resource/:/app/resource
+        - /opt/dockerstore/pallas-bot/accounts/:/app/accounts
+        - /opt/dockerstore/pallas-bot/.env.prod:/app/.env.prod
+    ...
+    volumes:
+    # 同上
+      - /opt/dockerstore/mongo/data:/data/db
+      - /opt/dockerstore/mongo/logs:/var/log/mongodb
+    ...
+    ```
+
+2. 如果你想使用牛牛的 AI 功能（CPU 推理），请为镜像添加标签 `latest-ai`：
+
+    ```yml
+    ...
+      pallasbot:
+        container_name: pallasbot
+        image: misteo/pallas-bot:latest-ai
+        restart: always
+    ...
+    ```
+
+3. 默认提供的 `docker-compose.yml` 中包含了 `qsign`，你可以根据需要修改 `ANDROID_ID` 和端口等其他参数。推荐在此处使用 `qsign` 而不是自己另外部署，因为你可能会遇到网络等问题。
+
+    ```yml
+    ...
+      qsign:
+        container_name: qsign
+        image: xzhouqd/qsign:8.9.63
+        environment:
+        - PORT=8080
+        - COUNT=3
+        - ANDROID_ID=114514
+        restart: always
+    ...
+    ```
+
+    注意，此端口不会和 `pallasbot` 容器的端口冲突。
+
+4. 在 docker-compose.yml 所在目录下创建 [.env.prod](../.env.prod) 文件，并根据需要填写相关基础功能参数或 AI 功能参数。
+
+## 启动与登录牛牛
+
+### 启动牛牛
+
+一键启动！
+
+插件形式安装的 Docker Compose 请使用 `docker compose` 代替 `docker-compose`
+
+```bash
+# Linux root 用户在 docker-compose.yml 所在目录下执行
+docker-compose up -d
+# Windows 请使用 powershell 直接执行，无需管理员权限，请不要在 wsl 内执行
+```
+
+由于 AI 版镜像较大（CPU 版本需要拉取 4.1G，解压后占空间 9.64G），在此之前也可以先使用 `docker compose pull` 拉取最新镜像。
+
+### 查看日志
+
+通过 `docker-compose logs -f` 查看实时日志，启动完成后就可以访问后台并登陆账号了。若你没有使用 AI 版本镜像，日志中报错未成功加载 `chat` 和 `sing` 插件是正常的，因为基础版镜像未安装相关依赖。
+
+### 登录账号与qsign
+
+请参考 [访问后台并登陆账号](Deployment.md##访问后台并登陆账号)
+
+记得在配置文件中填写 `sign-server`，并修改 `device.json` 中的 `android_id` 字段为 `qsign` 容器配置的 `ANDROID_ID`。
+
+注意，使用 docker 部署时牛牛的配置文件中应该这样填写 `sign-server`：
+
+```yml
+sign-server: 'http://qsign:8080'
+```
+
+host 应填写 `qsign` 容器的名称，端口应填写环境变量 `PORT` 所设的端口。
+
+## 后续更新
+
+```bash
+# Linux root 用户在 docker-compose.yml 所在目录下执行
+docker-compose down     # 停止容器
+docker-compose pull     # 拉取最新镜像
+docker-compose up -d    # 重新启动容器
+# Windows 请使用 powershell 直接执行，无需管理员权限，请不要在 wsl 内执行
+```


### PR DESCRIPTION
目前 sing 和 tts 默认情况下会有 `librosa` 等依赖冲突，paddlespeech 的依赖真的是一言难尽。。。AI 功能一个镜像 build 十几分钟，写 `Dockerfile` 写得非常痛苦。。。希望未来的更新能着重解决一下 AI 功能依赖安装的问题，争取弄一个 `ai_requirements.txt`。